### PR TITLE
Fix issue where no applications are shown if a search directory cannot be found.

### DIFF
--- a/src/xfce4-finder.cc
+++ b/src/xfce4-finder.cc
@@ -969,7 +969,7 @@ void on_search_text_change(){
             //iterate directories
             if( (p_directory = opendir(directory_text.data())) == NULL){
                 std::cerr << "Error: Could not open directory " << directory_text << std::endl;
-                return;
+                continue;
             }
 
             while( (p_entry = readdir(p_directory)) != NULL ){


### PR DESCRIPTION
If a directory does not exist (e.g. /usr/share/applications/kde4) then the code
in on_search_text_change() would stop processing an no applications would appear.

Instead of returning if opendir(directory_text.data()) fails, just continue processing.

This probably comes from there being no guarantee (no invariant) that the standard library (std::vector) would not reorder the search directory entries and not maintain the order specified in the source.